### PR TITLE
Client certificate url decode

### DIFF
--- a/src/main/java/nl/clockwork/ebms/server/servlet/ClientCertificateManagerFilter.java
+++ b/src/main/java/nl/clockwork/ebms/server/servlet/ClientCertificateManagerFilter.java
@@ -17,6 +17,8 @@ package nl.clockwork.ebms.server.servlet;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
@@ -76,11 +78,13 @@ public class ClientCertificateManagerFilter implements Filter
 		}
 	}
 
-	private X509Certificate decode(String certificate) throws CertificateException
-	{
+	private X509Certificate decode(String certificate) throws CertificateException, UnsupportedEncodingException {
 		if (StringUtils.isBlank(certificate))
 			return null;
-		val is = new ByteArrayInputStream(certificate.getBytes(Charset.defaultCharset()));
+
+		val charset = Charset.defaultCharset();
+		val decodedCertificate = URLDecoder.decode(certificate, charset.toString());
+		val is = new ByteArrayInputStream(decodedCertificate.getBytes(charset));
 		val cf = CertificateFactory.getInstance("X509");
 		return (X509Certificate)cf.generateCertificate(is);
 	}


### PR DESCRIPTION
- Add URL decode for the x509CertificateHeader in client certificate filter

Reason for this change is that I encountered a bug where header values with spaces (eg. the certificate header) was being URL encoded and I got an error with parsing the certificate string to a X509Certificate instance as it could not read an URL encoded string.

I have read in the documentation for the properties under section ["SSL"](https://eluinstra.github.io/ebms-admin/ebms-admin/properties.html#ssl) that the send client certificate is required to be Base64 DER-encoded. I am using an encoded PEM certificate and as this contains spaces in my case, an URL decoding had to be done in order for it to parse correctly to a `X509Certificate` instance.

Maybe this PR is not complete and is a start for a bigger improvement to support both DER and PEM certificates (maybe via the properties), but this change introduces a working solution for encoded PEM certificates.